### PR TITLE
Alex withblock

### DIFF
--- a/packages/python/pyfora/pyAst/NodeVisitorBases.py
+++ b/packages/python/pyfora/pyAst/NodeVisitorBases.py
@@ -77,7 +77,9 @@ class SemanticOrderNodeTransvisitor(ast.NodeTransformer):
     """Modifies ast.NodeTransformer visitation order and enables to visit lists of ast.Node.
 
     It is called a 'transvisitor' because it implements a transformer but only
-    performs a visit (i.e., it does not modify the ast)
+    performs a visit (i.e., it should not modify the AST). This implementation
+    detail is exposed to the user because they must be aware of it to correctly
+    implement a derived class.
     """
     def generic_visit(self, node):
         if isinstance(node, list):

--- a/packages/python/pyfora/pyAst/NodeVisitorBases.py
+++ b/packages/python/pyfora/pyAst/NodeVisitorBases.py
@@ -21,7 +21,9 @@ class VisitDone(Exception):
     pass
 
 def isScopeNode(pyAstNode):
-    if isinstance(pyAstNode, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.Lambda, ast.GeneratorExp)):
+    """Return true iff argument is a scoped node."""
+    if isinstance(pyAstNode, (ast.Module, ast.ClassDef,
+                              ast.FunctionDef, ast.Lambda, ast.GeneratorExp)):
         return True
     else:
         return False
@@ -50,6 +52,11 @@ class InScopeSaveRestoreValue(object):
 class ScopedSaveRestoreComputedValue(object):
     """ Generic Context Manager for GenericScopedVisitors."""
     def __init__(self, valueGetter, valueSetter, valueComputer):
+        """
+        valueGetter: function that returns the current value
+        valueSetter: function that takes a value and sets it as current
+        valueComputer: function that takes (node, old_value) and computes new value
+        """
         self.valueGetter = valueGetter
         self.valueSetter = valueSetter
         self.valueComputer = valueComputer

--- a/packages/python/pyfora/pyAst/NodeVisitorBases.py
+++ b/packages/python/pyfora/pyAst/NodeVisitorBases.py
@@ -67,7 +67,7 @@ class ScopedSaveRestoreComputedValue(object):
 ##########################################################################
 # Visitor Base Classes
 class NodeVisitorBase(ast.NodeVisitor):
-    """Extends ast.NodeVisitor.generic_visit to also visit lists of ast.Node."""
+    """Modifies ast.NodeVisitor visitation order and enables to visit lists of ast.Node."""
     def generic_visit(self, node):
         if isinstance(node, list):
             self._generic_visit_list(node)
@@ -129,7 +129,7 @@ class GenericInScopeVisitor(NodeVisitorBase):
         return self._isInDefinition
     def _setIsInDefinition(self, value):
         self._isInDefinition = value
-    def _isInDefinitionMgr(self, newValue = True):
+    def _isInDefinitionMgr(self, newValue=True):
         self._isInDefinitionValueManager.newValue = newValue
         return self._isInDefinitionValueManager
 

--- a/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
+++ b/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
@@ -69,7 +69,7 @@ class _CollectBoundValuesInScopeTransvisitor(NodeVisitorBases.GenericInScopeTran
 
     def getBoundValues(self, getPositions=False):
         self._cachedCompute()
-        if getPositions is True:
+        if getPositions:
             return self._boundVarsWithPos.union(self._boundNamesWithPos)
         else:
             return self.getBoundVariables().union(self.getBoundNames())
@@ -232,7 +232,7 @@ class _FreeVariableMemberAccessChainsTransvisitor(NodeVisitorBases.GenericScoped
         (chainOrNone, root) = _memberAccessChainWithLocOrNone(node)
         if chainOrNone is not None:
             self.processChain(chainOrNone, root.ctx, root.lineno, root.col_offset)
-        elif allow_recursion is True:
+        elif allow_recursion:
             # required to recurse deeper into the AST, but only do it if
             # _freeVariableMemberAccessChain was None, indicating that it
             # doesn't want to consume the whole expression

--- a/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
+++ b/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
@@ -285,7 +285,6 @@ class _FreeVariableMemberAccessChainsCollapsingTransformer(_FreeVariableMemberAc
                     ast.Name(self.chain_to_new_name[chain], node.ctx),
                     node
                     )
-            return node
         return self.generic_visit(node)
 
 

--- a/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
+++ b/packages/python/pyfora/pyAst/PyAstFreeVariableAnalyses.py
@@ -281,7 +281,7 @@ class _FreeVariableMemberAccessChainsCollapsingTransformer(ast.NodeTransformer):
             chain = tuple(chainOrNone)
             if chain in self.chain_to_new_name:
                 return ast.copy_location(
-                    ast.Name(self.chain_to_new_name[chain], ast.Load()),
+                    ast.Name(self.chain_to_new_name[chain], node.ctx),
                     node
                     )
             return node
@@ -328,4 +328,3 @@ def collapseFreeVariableMemberAccessChains(pyAstNode,
     pyAstNode = PyAstUtil.getRootInContext(pyAstNode, isClassContext)
     vis = _FreeVariableMemberAccessChainsCollapsingTransformer(chain_to_name)
     return vis.visit(pyAstNode)
-

--- a/packages/python/pyfora/pyAst/PyAstUtil.py
+++ b/packages/python/pyfora/pyAst/PyAstUtil.py
@@ -261,8 +261,8 @@ def _collectDataMembersSetInInitAst(initAst):
             )
 
     return _extractSimpleSelfMemberAssignments(
-        initFunctionDef = initAst,
-        selfName = selfArg.id
+        initFunctionDef=initAst,
+        selfName=selfArg.id
         )
 
 
@@ -335,6 +335,7 @@ def _computeInitMethodAstOrNone(pyClassObject):
     return tr
 
 def getRootInContext(pyAstNode, isClassContext):
+    """Return the given node either as-is, or wrapped in a Module node."""
     if not NodeVisitorBases.isScopeNode(pyAstNode):
         raise Exceptions.InternalError(
             "Unsupported type of root node in Analysis (%s)."

--- a/packages/python/pyfora/pyAst/PyAstUtil.py
+++ b/packages/python/pyfora/pyAst/PyAstUtil.py
@@ -353,7 +353,7 @@ def getRootInContext(pyAstNode, isClassContext):
     return pyAstNode
 
 
-class _OuterScopeCountingVisitor(NodeVisitorBases.GenericInScopeVisitor):
+class _OuterScopeCountingVisitor(NodeVisitorBases.GenericInScopeTransvisitor):
     """Scan the current scope and count various types of statements and expressions"""
     def __init__(self, root):
         super(_OuterScopeCountingVisitor, self).__init__(root)
@@ -383,10 +383,12 @@ class _OuterScopeCountingVisitor(NodeVisitorBases.GenericInScopeVisitor):
     def visit_Return(self, node):
         self._returnCount += 1
         self._returnLocs.append(node.lineno)
+        return node
 
     def visit_Yield(self, node):
         self._yieldCount += 1
         self._yieldLocs.append(node.lineno)
+        return node
 
 
 @CachedByArgs

--- a/packages/python/pyfora/pyAst/PyAstUtil.py
+++ b/packages/python/pyfora/pyAst/PyAstUtil.py
@@ -24,6 +24,9 @@ import textwrap
 
 LINENO_ATTRIBUTE_NAME = 'lineno'
 
+def areAstsIdentical(ast1, ast2):
+    return ast.dump(ast1) == ast.dump(ast2)
+
 def CachedByArgs(f):
     """Function decorator that adds a simple memo to 'f' on its arguments"""
     cache = {}

--- a/packages/python/pyfora/src/PyObjectWalker.cpp
+++ b/packages/python/pyfora/src/PyObjectWalker.cpp
@@ -928,10 +928,11 @@ void _handleUnresolvedFreeVariableException(const PyObject* filename)
             );
         }
     else {
-        Py_DECREF(exception);
-        Py_DECREF(v);
-        Py_DECREF(tb);
-        throw std::runtime_error("expected an UnresolvedFreeVariableException");
+        PyErr_Restore(exception, v, tb);
+        throw std::runtime_error(
+            "PyObjectWalker::<anonymous namespace>::"
+            "_handleUnresolvedFreeVariableException: " +
+            PyObjectUtils::format_exc());
         }
 
     Py_DECREF(exception);

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -20,6 +20,19 @@ import textwrap
 import unittest
 
 class PyAstFreeVariableAnalyses_test(unittest.TestCase):
+    def test_multiple_assignment(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                x = y = z = w
+                """
+                )
+            )
+        self.assertEqual(
+            set(['w']),
+            PyAstFreeVariableAnalyses.getFreeVariables(tree)
+            )
+
     def test_members(self):
         tree = ast.parse(
             textwrap.dedent(
@@ -171,8 +184,8 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
             textwrap.dedent(
                 """
                 class C(object):
-                    x = x
                     y = x
+                    x = 0
                 """
                 )
             )
@@ -326,6 +339,20 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
 
         self.assertEqual(
             set(['w']),
+            PyAstFreeVariableAnalyses.getFreeVariables(tree)
+            )
+
+    def test_freeVariables_Assign_2(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                w = ((x, y), z)
+                """
+                )
+            )
+
+        self.assertEqual(
+            set(['x', 'y', 'z']),
             PyAstFreeVariableAnalyses.getFreeVariables(tree)
             )
 
@@ -975,7 +1002,63 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
         tree = ast.parse(
             textwrap.dedent(
                 """
+                class C:
+                  x.y.z = 3
+                  def f(self):
+                    y = 2
+                    class C:
+                      def g(self, arg):
+                        x.y.z + y + arg
+                C.f
+                """
+                )
+            )
+
+        res = PyAstFreeVariableAnalyses.getFreeVariableMemberAccessChains(tree)
+
+        self.assertEqual(
+            set([('x', 'y', 'z')]),
+            res
+            )
+
+    def test_freeVariableMemberAccessChains_4(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                x.y.z = 1
+                q = x.y.z
+                """
+                )
+            )
+
+        res = PyAstFreeVariableAnalyses.getFreeVariableMemberAccessChains(tree)
+
+        self.assertEqual(
+            set([('x', 'y', 'z')]),
+            res
+            )
+
+    def test_freeVariableMemberAccessChains_5(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
                 x.y.z = 2
+                """
+                )
+            )
+
+        res = PyAstFreeVariableAnalyses.getFreeVariableMemberAccessChains(tree)
+
+        self.assertEqual(
+            set([('x', 'y', 'z')]),
+            res
+            )
+
+    def test_freeVariableMemberAccessChains_6(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                q = x.y.z = 2
                 """
                 )
             )

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -48,7 +48,7 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
-        expectedResult = set(['x','y'])
+        expectedResult = set(['x', 'y'])
         self.assertEqual(
             expectedResult,
             PyAstFreeVariableAnalyses.getFreeVariables(tree)
@@ -65,7 +65,7 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
-        expectedResult = set(['range','isinstance'])
+        expectedResult = set(['range', 'isinstance'])
         self.assertEqual(
             expectedResult,
             PyAstFreeVariableAnalyses.getFreeVariables(tree)
@@ -81,7 +81,7 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
-        expectedResult = set(['range','isinstance','slice','list'])
+        expectedResult = set(['range', 'isinstance', 'slice', 'list'])
         self.assertEqual(
             expectedResult,
             PyAstFreeVariableAnalyses.getFreeVariables(tree)
@@ -858,12 +858,12 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
 
         self.assertEqual(
             set([]),
-            PyAstFreeVariableAnalyses.getFreeVariables(tree.body[0], isClassContext = False)
+            PyAstFreeVariableAnalyses.getFreeVariables(tree.body[0], isClassContext=False)
             )
 
         self.assertEqual(
             set(['fib']),
-            PyAstFreeVariableAnalyses.getFreeVariables(tree.body[0], isClassContext = True)
+            PyAstFreeVariableAnalyses.getFreeVariables(tree.body[0], isClassContext=True)
             )
 
     def test_freeVariables_name_substring_bug(self):

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -1128,5 +1128,20 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
         self.assertTrue(tree2 is not None)
         self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
 
+    def test_FreeVariableTransformer_3(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                def g(y):
+                    return x.y.z.__str__()
+                """
+                )
+            )
+        tree1 = copy.deepcopy(tree)
+        tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
+                        tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
+        self.assertTrue(tree2 is not None)
+        self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -1088,11 +1088,13 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
 
     def test_TransvisitorsDontModifyTree(self):
         tree = ast.parse(self.some_python_code)
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         noopTransformer = NodeVisitorBases.SemanticOrderNodeTransvisitor()
         tree2 = noopTransformer.visit(tree1)
 
-        self.assertTrue(tree2 is not None, 'tree2 is None')
+        self.assertIsNotNone(tree2)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
 
         scopeMgr = NodeVisitorBases.InScopeSaveRestoreValue(
@@ -1101,13 +1103,13 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
         noopTransformer = NodeVisitorBases.GenericScopedTransvisitor(scopeMgr)
         tree3 = noopTransformer.visit(tree1)
 
-        self.assertTrue(tree3 is not None, 'tree3 is None')
+        self.assertIsNotNone(tree3)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree3))
 
         freeVarsVisitor = PyAstFreeVariableAnalyses._FreeVariableMemberAccessChainsTransvisitor()
         tree4 = freeVarsVisitor.visit(tree1)
 
-        self.assertTrue(tree4 is not None, 'tree4 is None')
+        self.assertIsNotNone(tree4)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree4))
 
 
@@ -1120,10 +1122,12 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
+        self.assertIsNotNone(tree2)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
 
     def test_FreeVariableTransformer_2(self):
@@ -1135,11 +1139,13 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
-        self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
+        self.assertIsNotNone(tree2)
+        self.assertFalse(PyAstUtil.areAstsIdentical(tree, tree2))
 
     def test_FreeVariableTransformer_3(self):
         tree = ast.parse(
@@ -1150,11 +1156,13 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
-        self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
+        self.assertIsNotNone(tree2)
+        self.assertFalse(PyAstUtil.areAstsIdentical(tree, tree2))
 
     def test_FreeVariableTransformer_4(self):
         tree = ast.parse(
@@ -1167,10 +1175,12 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
+        self.assertIsNotNone(tree2)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
 
     def test_FreeVariableTransformer_5(self):
@@ -1184,10 +1194,12 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
+        self.assertIsNotNone(tree2)
         self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
 
     def test_FreeVariableTransformer_6(self):
@@ -1201,11 +1213,13 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
                 """
                 )
             )
+        # deep-copy tree because transformers modify the AST in place
+        # making the test of areAstsIdentical(tree, tree') meaningless
         tree1 = copy.deepcopy(tree)
         tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
                         tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
-        self.assertTrue(tree2 is not None)
-        self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
+        self.assertIsNotNone(tree2)
+        self.assertFalse(PyAstUtil.areAstsIdentical(tree, tree2))
 
 
 

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 
 import pyfora.pyAst.PyAstFreeVariableAnalyses as PyAstFreeVariableAnalyses
+import pyfora.pyAst.NodeVisitorBases as NodeVisitorBases
 import pyfora.Exceptions as Exceptions
 import pyfora.pyAst.PyAstUtil as PyAstUtil
 import ast
@@ -1070,7 +1071,31 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
             res
             )
 
+    def test_SemanticOrderNodeTransformer(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                def g(x):
+                    return x.y.z
+                """
+                )
+            )
+        noopTransformer = NodeVisitorBases.SemanticOrderNodeTransvisitor()
+        tree2 = noopTransformer.visit(tree)
 
+        self.assertTrue(tree2 is not None, 'tree2 is None')
+        self.assertTrue(tree is tree2)
+
+        scopeMgr = NodeVisitorBases.InScopeSaveRestoreValue(
+                    lambda :  True,
+                    lambda x: None)
+
+        noopTransformer = NodeVisitorBases.GenericScopedTransvisitor(scopeMgr)
+        tree2 = noopTransformer.visit(tree)
+
+        self.assertTrue(tree2 is not None, 'tree2 is None')
+        print ast.dump(tree2)
+        self.assertTrue(tree is tree2, ast.dump(tree2))
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
+++ b/packages/python/pyfora/test/PyAstFreeVariableAnalyses_test.py
@@ -1156,5 +1156,58 @@ class PyAstFreeVariableAnalyses_test(unittest.TestCase):
         self.assertTrue(tree2 is not None)
         self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
 
+    def test_FreeVariableTransformer_4(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                def f(x,y):
+                    def g(x):
+                        return x.y.z
+                    return x.y.z, g(y)
+                """
+                )
+            )
+        tree1 = copy.deepcopy(tree)
+        tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
+                        tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
+        self.assertTrue(tree2 is not None)
+        self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
+
+    def test_FreeVariableTransformer_5(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                def f(x,y):
+                    def g(z):
+                        return x.y.z
+                    return x.y.z, g(y)
+                """
+                )
+            )
+        tree1 = copy.deepcopy(tree)
+        tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
+                        tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
+        self.assertTrue(tree2 is not None)
+        self.assertTrue(PyAstUtil.areAstsIdentical(tree, tree2))
+
+    def test_FreeVariableTransformer_6(self):
+        tree = ast.parse(
+            textwrap.dedent(
+                """
+                def f(y,z):
+                    def g(x):
+                        return x.y.z
+                    return x.y.z, g(y)
+                """
+                )
+            )
+        tree1 = copy.deepcopy(tree)
+        tree2 = PyAstFreeVariableAnalyses.collapseFreeVariableMemberAccessChains(
+                        tree1, {('x', 'y', 'z'):'x_y_z'}, isClassContext=False)
+        self.assertTrue(tree2 is not None)
+        self.assertTrue(not PyAstUtil.areAstsIdentical(tree, tree2))
+
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/ufora/FORA/python/PurePython/WithRegularPython_test.py
+++ b/ufora/FORA/python/PurePython/WithRegularPython_test.py
@@ -219,6 +219,7 @@ class WithRegularPython_test(unittest.TestCase):
                     with helpers.python:
                         x = sz
 
+                self.assertTrue(x == sz)
 
     def test_import_large_numpy_arrays(self):
         with self.create_executor() as fora:

--- a/ufora/FORA/python/PurePython/WithRegularPython_test.py
+++ b/ufora/FORA/python/PurePython/WithRegularPython_test.py
@@ -30,7 +30,7 @@ class EvaluateBodyAndReturnContext:
         pass
 
     def __pyfora_context_apply__(self, body):
-        res =  __inline_fora(
+        res = __inline_fora(
             """fun(@unnamed_args:(body), ...) {
                        body()
                        }"""
@@ -126,11 +126,11 @@ class WithRegularPython_test(unittest.TestCase):
 
             with fora.remotely.downloadAll():
                 with helpers.python:
-                    #'x' is local to the with block - it won't be updated
+                    # 'x' is local to the with block - it won't be updated
                     x[10] = 20
 
-                    #but the copy we send back will be because it gets 
-                    #duplicated back into the surrounding context
+                    # but the copy we send back will be because it gets
+                    # duplicated back into the surrounding context
                     y = x
 
             self.assertEqual(x, {})
@@ -144,7 +144,7 @@ class WithRegularPython_test(unittest.TestCase):
         with self.create_executor() as fora:
             with fora.remotely.downloadAll():
                 with helpers.python:
-                    #'x' is local to the with block - it won't be updated
+                    # 'x' is local to the with block - it won't be updated
                     x = aFunc(20)
 
             self.assertEqual(x, 30)
@@ -159,7 +159,7 @@ class WithRegularPython_test(unittest.TestCase):
 
     def test_module_references_inside_of_functions(self):
         def f():
-            #this can't work in pyfora right now
+            # this can't work in pyfora right now
             z = {}
             z[10] = 10
             return numpy.ones(z[10]).shape[0]
@@ -205,16 +205,16 @@ class WithRegularPython_test(unittest.TestCase):
     def test_numpy_arrays_out_of_process(self):
         with self.create_executor() as fora:
             with fora.remotely.downloadAll():
-                x = numpy.array([1,2,3,4])
+                x = numpy.array([1, 2, 3, 4])
 
                 with helpers.python:
                     x = x + x
 
-            self.assertTrue(numpy.all(x == numpy.array([2,4,6,8])))
+            self.assertTrue(numpy.all(x == numpy.array([2, 4, 6, 8])))
 
     def test_with_block_in_loop(self):
         with self.create_executor() as fora:
-            for sz in [1,2,3,4]:
+            for sz in [1, 2, 3, 4]:
                 with fora.remotely.downloadAll():
                     with helpers.python:
                         x = sz
@@ -223,7 +223,7 @@ class WithRegularPython_test(unittest.TestCase):
     def test_import_large_numpy_arrays(self):
         with self.create_executor() as fora:
             sz = 1000000
-            
+
             with fora.remotely.downloadAll():
                 with helpers.python:
                     x = numpy.ones(sz)
@@ -256,9 +256,9 @@ class WithRegularPython_test(unittest.TestCase):
 
                     if path.endswith("pyc"):
                         path = path[:-1]
-                    
+
                     x = open(path, "rb").readline()
-                    
+
             self.assertTrue("Ufora Inc." in x)
 
 


### PR DESCRIPTION
These commits fix some bugs in the collapseFreeVariableMemberAccessChains transformer and ports the code of the other analyses to the NodeTransformer class (from the NodeVisitor class, which is the parent class of NodeTransformer). This is done to avoid code duplication of various analyses.

Transvisitor analyses are derived from the NodeTransformer class, but do not themselves modify the AST. They must, however, be careful to correctly implement transformer semantics in case a class that derives from it, is a true transformer (e.g., Optimus Prime).
